### PR TITLE
Pin Ubuntu release for increased stability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # gokaygurcan/dockerfile-nginx
 
-FROM gokaygurcan/ubuntu:latest
+FROM gokaygurcan/ubuntu:focal
 
 # metadata
 LABEL maintainer "Gökay Gürcan <docker@gokaygurcan.com>"


### PR DESCRIPTION
Using latest is prone to errors if the image will ever update.